### PR TITLE
Include `///` and `//!` comments when searching for `TODO`s

### DIFF
--- a/bad/todo.zig
+++ b/bad/todo.zig
@@ -1,9 +1,12 @@
-// ./bad/todo.zig:6:1: TODO: maybe the return type should be !void
-// ./bad/todo.zig:8:5: TODO: switch to something that also prints in release mode
+// ./bad/todo.zig:5:1: TODO: add top-level documentation
+// ./bad/todo.zig:9:1: TODO: maybe the return type should be !void
+// ./bad/todo.zig:11:5: TODO: switch to something that also prints in release mode
+
+//! TODO: add top-level documentation
 
 const std = @import("std");
 
-// TODO maybe the return type should be !void
+/// TODO maybe the return type should be !void
 pub fn main() void {
     // TODO switch to something that also prints in release mode
     std.log.info("{s}", .{"hello world"});


### PR DESCRIPTION
Also trim `:` if it's found after the TODO (e.g. `// TODO: something`)

---

Note: The logic for skipping `:` is a little verbose to avoid the (admittedly unlikely) situation where it could trim too many colons from something like `// TODO ::SomeWeirdThing`